### PR TITLE
feat: add optional leveldb cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+.npmrc
+node_modules
+test/.cache

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const inlineLinks = require('remark-inline-links')
 const grayMatter = require('gray-matter')
 const pify = require('pify')
 const hasha = require('hasha')
-const sortObject = require('sort-object')
+const stableStringify = require('json-stable-stringify')
 
 const renderer = remark()
   .use(slug)
@@ -62,11 +62,10 @@ function makeHash (markdownString, opts) {
   // ignore `cache` prop when creating hash
   delete hashableOpts.cache
 
+  // deterministic stringifier gets a consistent hash from stringified results
   // object keys are sorted to ensure {a:1, b:2} has the same hash as {b:2, a:1}
   // empty object should become an empty string, not {}
-  const optsString = Object.keys(hashableOpts).length
-    ? JSON.stringify(sortObject(hashableOpts))
-    : ''
+  const optsString = Object.keys(hashableOpts).length ? stableStringify(hashableOpts) : ''
 
   return hasha(markdownString + optsString)
 }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const autolinkHeadings = require('remark-autolink-headings')
 const inlineLinks = require('remark-inline-links')
 const grayMatter = require('gray-matter')
 const pify = require('pify')
+const hasha = require('hasha')
 
 const renderer = remark()
   .use(slug)
@@ -16,6 +17,7 @@ const renderer = remark()
   .use([hljs, html], {sanitize: false})
 
 module.exports = async function hubdown (markdownString, opts = {}) {
+  const hash = hasha(markdownString)
   const defaults = {
     frontmatter: false
   }
@@ -24,6 +26,15 @@ module.exports = async function hubdown (markdownString, opts = {}) {
   let data = {}
   let content = markdownString
 
+  // check the cache for preprocessed markdown
+  if (opts.cache) {
+    const existing = await opts.cache.get(hash).catch(err => {
+      console.debug(err)
+      return null
+    })
+    if (existing) return existing
+  }
+
   if (opts.frontmatter) {
     const parsed = grayMatter(markdownString)
     data = parsed.data
@@ -31,5 +42,10 @@ module.exports = async function hubdown (markdownString, opts = {}) {
   }
 
   const md = await pify(renderer.process)(content)
-  return Object.assign(data, {content: md.contents})
+  Object.assign(data, {content: md.contents})
+
+  // save processed markdown in cache
+  if (opts.cache) await opts.cache.put(hash, data)
+
+  return data
 }

--- a/index.js
+++ b/index.js
@@ -30,10 +30,12 @@ module.exports = async function hubdown (markdownString, opts = {}) {
 
   // check the cache for preprocessed markdown
   if (opts.cache) {
-    const existing = await opts.cache.get(hash).catch(err => {
-      console.debug(err)
-      return null
-    })
+    let existing = false
+    try {
+      existing = await opts.cache.get(hash)
+    } catch (err) {
+      if (!err.notFound) console.error(err)
+    }
     if (existing) return existing
   }
 

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "cheerio": "^1.0.0-rc.2",
+    "level": "^4.0.0",
     "mocha": "^3.5.3",
+    "semantic-release": "^8.0.3",
     "standard": "^10.0.3",
-    "standard-markdown": "^4.0.2",
-    "semantic-release": "^8.0.3"
+    "standard-markdown": "^4.0.2"
   },
   "dependencies": {
     "gray-matter": "^3.0.7",
+    "hasha": "^3.0.0",
     "pify": "^3.0.0",
     "remark": "^8.0.0",
     "remark-autolink-headings": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "gray-matter": "^3.0.7",
     "hasha": "^3.0.0",
+    "json-stable-stringify": "^1.0.1",
     "pify": "^3.0.0",
     "remark": "^8.0.0",
     "remark-autolink-headings": "^5.0.0",
@@ -29,8 +30,7 @@
     "remark-highlight.js": "^5.0.0",
     "remark-html": "^6.0.1",
     "remark-inline-links": "^3.0.4",
-    "remark-slug": "^4.2.3",
-    "sort-object": "^3.0.2"
+    "remark-slug": "^4.2.3"
   },
   "engines": {
     "node": ">=7"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "remark-highlight.js": "^5.0.0",
     "remark-html": "^6.0.1",
     "remark-inline-links": "^3.0.4",
-    "remark-slug": "^4.2.3"
+    "remark-slug": "^4.2.3",
+    "sort-object": "^3.0.2"
   },
   "engines": {
     "node": ">=7"

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,26 @@ containing the parsed HTML:
 }
 ```
 
+## Usage with Cache
+
+hubdown's `remark` markdown parser is pretty fast, but things can start to slow 
+down when you're processing hundreds or thousands of files. To make life easier 
+in these situations you can use hubdown's optional cache, which stores 
+preprocessed markdown for fast retrieval on subsequent runs.
+
+To use the cache, bring your own [level](https://ghub.io/level) instance and
+supply it as an option to hubdown. This helps keep hubdown lean on (native) 
+dependencies for users who don't need the cache.
+
+```js
+const hubdown = require('hubdown')
+const cache = require('level')('./my-hubdown-cache')
+
+hubdown('I will be cached.', {cache}).then(doc => {
+  console.log(doc)
+})
+```
+
 ## API
 
 ### `hubdown(markdownString[, options])`
@@ -58,6 +78,8 @@ Arguments:
 - `options` Object - (optional)
   - `frontmatter` Boolean - Whether or not to try to parse [YML frontmatter] in 
     the file. Defaults to `false`.
+  - `cache` [LevelDB](https://ghub.io/level) - An optional `level` instance in which
+  to store preprocessed content. See [Usage with Cache](#usage-with-cache).
 
 Returns a promise. The resolved object looks like this:
 

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,8 @@ const path = require('path')
 const {before, describe, it} = require('mocha')
 const hubdown = require('..')
 const cheerio = require('cheerio')
+const level = require('level')
+const hasha = require('hasha')
 const fixtures = {
   basic: fs.readFileSync(path.join(__dirname, 'fixtures/basic.md'), 'utf8'),
   emoji: fs.readFileSync(path.join(__dirname, 'fixtures/emoji.md'), 'utf8'),
@@ -75,6 +77,30 @@ describe('hubdown', () => {
       file.title.should.equal('Project of the Week: WebTorrent')
       file.author.should.equal('zeke')
       file.date.should.equal('2017-03-14')
+    })
+  })
+
+  describe('caching', () => {
+    const db = level('.', {valueEncoding: 'json'})
+
+    it('accepts an optional leveldb instance as a cache', async () => {
+      const hash = hasha(fixtures.basic)
+      await db.put(hash, {content: 'I came from the cache'})
+
+      const uncached = await hubdown(fixtures.basic)
+      uncached.content.should.include('<h2')
+
+      const cached = await hubdown(fixtures.basic, {cache: db})
+      cached.content.should.equal('I came from the cache')
+    })
+
+    it('saves to the cache', async () => {
+      const hash = hasha('Cache me please')
+      await db.del(hash)
+
+      await hubdown('Cache me please', {cache: db})
+      const cached = await db.get(hash)
+      cached.content.should.equal('<p>Cache me please</p>\n')
     })
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -81,7 +81,7 @@ describe('hubdown', () => {
   })
 
   describe('caching', () => {
-    const db = level('.', {valueEncoding: 'json'})
+    const db = level('./test/.cache', {valueEncoding: 'json'})
 
     it('accepts an optional leveldb instance as a cache', async () => {
       const hash = hasha(fixtures.basic)


### PR DESCRIPTION
hubdown's `remark` markdown parser is pretty fast, but things can start to slow down when you're processing hundreds or thousands of files. To make life easier in these situations you can use hubdown's optional cache, which stores preprocessed markdown for fast retrieval on subsequent runs.

To use the cache, bring your own [level](https://ghub.io/level) instance and supply it as an option to hubdown. This helps keep hubdown lean on (native) dependencies for users who don't need the cache.

```js
const hubdown = require('hubdown')
const cache = require('level')('./my-hubdown-cache')

hubdown('I will be cached.', {cache}).then(doc => {
  console.log(doc)
})
```

- [x] Implementation
- [x] Tests
- [x] maybe include a hash of the options object as part of the cache key.
- [x] Documentation