### PR TITLE
fix: last feature didn't get released

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
 notifications:
   email: false
 node_js:
-  - '7'
   - '8'
 before_script:
   - npm prune

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   "license": "MIT",
   "scripts": {
     "test": "mocha && standard --fix && standard-markdown",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "cheerio": "^1.0.0-rc.2",
     "level": "^4.0.0",
     "mocha": "^3.5.3",
-    "semantic-release": "^8.0.3",
+    "semantic-release": "^15.9.12",
     "standard": "^10.0.3",
     "standard-markdown": "^4.0.2"
   },


### PR DESCRIPTION
When #8 landed, this happened in Travis:

```
npm ERR! Linux 4.4.0-112-generic
npm ERR! argv "/home/travis/.nvm/versions/node/v7.10.1/bin/node" "/home/travis/.nvm/versions/node/v7.10.1/bin/npm" "run" "semantic-release"
npm ERR! node v7.10.1
npm ERR! npm  v4.2.0
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! hubdown@0.0.0-development semantic-release: `semantic-release pre && npm publish && semantic-release post`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the hubdown@0.0.0-development semantic-release script 'semantic-release pre && npm publish && semantic-release post'.
```

I tried to update semantic release but that went a little wonky too:  https://github.com/semantic-release/semantic-release/issues/911

The setup process did actually make changes to package.json and .travis.yml though, so maybe that's enough to fix the above issue. 🤞 
