### PR TITLE
feat: add option to run custom remark plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,18 +10,11 @@ const pify = require('pify')
 const hasha = require('hasha')
 const stableStringify = require('json-stable-stringify')
 
-const renderer = remark()
-  .use(slug)
-  .use(autolinkHeadings, { behavior: 'wrap' })
-  .use(inlineLinks)
-  .use(emoji)
-  .use(highlight)
-  .use(html, { sanitize: false })
-
 module.exports = async function hubdown (markdownString, opts = {}) {
   const hash = makeHash(markdownString, opts)
 
   const defaults = {
+    runBefore: [],
     frontmatter: false
   }
   opts = Object.assign(defaults, opts)
@@ -45,6 +38,15 @@ module.exports = async function hubdown (markdownString, opts = {}) {
     data = parsed.data
     content = parsed.content
   }
+
+  const renderer = remark()
+    .use(opts.runBefore)
+    .use(slug)
+    .use(autolinkHeadings, { behavior: 'wrap' })
+    .use(inlineLinks)
+    .use(emoji)
+    .use(highlight)
+    .use(html, { sanitize: false })
 
   const md = await pify(renderer.process)(content)
   Object.assign(data, { content: md.contents })

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,7 @@ Arguments:
 
 - `markdownString` String - (required)
 - `options` Object - (optional)
+  - `runBefore` Array of [remark] plugins - Custom plugins to be run before the commonly used plugins listed [above](#plugins).
   - `frontmatter` Boolean - Whether or not to try to parse [YML frontmatter] in 
     the file. Defaults to `false`.
   - `cache` [LevelDB](https://ghub.io/level) - An optional `level` instance in which

--- a/test/index.js
+++ b/test/index.js
@@ -63,6 +63,18 @@ describe('hubdown', () => {
     })
   })
 
+  describe('runBefore', () => {
+    it('runs custom plugins', async () => {
+      let pluginDidRun = false
+      const plugin = () => (tree) => {
+        pluginDidRun = true
+        return tree
+      }
+      await hubdown(fixtures.basic, { runBefore: [plugin] })
+      pluginDidRun.should.equal(true)
+    })
+  })
+
   describe('frontmatter', () => {
     it('does not parse frontmatter by default', async () => {
       const file = await hubdown(fixtures.frontmatter)


### PR DESCRIPTION
In order to inject a custom transformer that we need to integrate fiddles in Electron's docs, this PR extends `hubdown` to accept custom remark plugins. These plugins are run before the commonly used plugins -> therefore the option's name: `runBefore`.