### PR TITLE
feat: add `ignoreMissing` option to allow skip valid language checking

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,18 @@
 declare namespace hubdown {
+  interface IHighlightOptions {
+    readonly prefix: string
+    readonly subset: boolean | Array<string>
+    readonly ignoreMissing: boolean
+    readonly plainText: Array<string>
+    readonly aliases: Record<string | Array<string>>
+    readonly languages: Record<string | Function>
+  }
+
   interface Options {
     readonly runBefore?: Array<any>;
     readonly frontmatter?: boolean;
     readonly cache?: any;
-    readonly ignoreMissing?: boolean
+    readonly highlight?: Partial<IHighlightOptions>
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ declare namespace hubdown {
     readonly runBefore?: Array<any>;
     readonly frontmatter?: boolean;
     readonly cache?: any;
+    readonly ignoreMissing?: boolean
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -44,9 +44,9 @@ module.exports = async function hubdown (markdownString, opts = {}) {
     content = parsed.content
   }
 
-  const processor = opts.runBefore.length === 0
-    ? defaultProcessor
-    : createProcessor(opts.runBefore)
+  const processor = opts.runBefore.length !== 0 || opts.ignoreMissing
+    ? createProcessor(opts.runBefore, opts.ignoreMissing)
+    : defaultProcessor
 
   const file = await processor.process(content)
   Object.assign(data, { content: String(file) })
@@ -73,7 +73,7 @@ function makeHash (markdownString, opts) {
   return hasha(markdownString + optsString)
 }
 
-function createProcessor (before) {
+function createProcessor (before, ignoreMissing) {
   return unified()
     .use(markdown)
     .use(before)
@@ -81,7 +81,13 @@ function createProcessor (before) {
     .use(remark2rehype, { allowDangerousHTML: true })
     .use(slug)
     .use(autolinkHeadings, { behavior: 'wrap' })
-    .use(highlight, { languages: { graphql: require('highlightjs-graphql').definer } })
+    .use(highlight,
+      {
+        languages: {
+          graphql: require('highlightjs-graphql').definer
+        },
+        ignoreMissing: !!ignoreMissing
+      })
     .use(raw)
     .use(html)
 }

--- a/index.js
+++ b/index.js
@@ -44,8 +44,8 @@ module.exports = async function hubdown (markdownString, opts = {}) {
     content = parsed.content
   }
 
-  const processor = opts.runBefore.length !== 0 || opts.ignoreMissing
-    ? createProcessor(opts.runBefore, opts.ignoreMissing)
+  const processor = opts.runBefore.length !== 0 || opts.highlight
+    ? createProcessor(opts.runBefore, opts.highlight)
     : defaultProcessor
 
   const file = await processor.process(content)
@@ -73,7 +73,7 @@ function makeHash (markdownString, opts) {
   return hasha(markdownString + optsString)
 }
 
-function createProcessor (before, ignoreMissing) {
+function createProcessor (before, highlightOpts) {
   return unified()
     .use(markdown)
     .use(before)
@@ -86,7 +86,7 @@ function createProcessor (before, ignoreMissing) {
         languages: {
           graphql: require('highlightjs-graphql').definer
         },
-        ignoreMissing: !!ignoreMissing
+        ...highlightOpts
       })
     .use(raw)
     .use(html)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@continuous-auth/semantic-release-npm": "^2.0.0",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "cheerio": "^1.0.0-rc.3",
     "level": "^5.0.1",
     "mocha": "^6.1.4",

--- a/readme.md
+++ b/readme.md
@@ -87,8 +87,7 @@ Arguments:
     the file. Defaults to `false`.
   - `cache` [LevelDB](https://ghub.io/level) - An optional `level` instance in which
     to store preprocessed content. See [Usage with Cache](#usage-with-cache).
-  - `ignoreMissing` - Swallow errors for missing languages (`boolean`, default: `false`). By default, unregistered syntaxes
-    throw an error when they are used. Pass `true` to swallow those errors and thus ignore code with unknown code languages.
+  - `highlight` - Object of [rehype-highlight](https://github.com/rehypejs/rehype-highlighthighlight#options) options.
 
 Returns a promise. The resolved object looks like this:
 

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,9 @@ Arguments:
   - `frontmatter` Boolean - Whether or not to try to parse [YML frontmatter] in
     the file. Defaults to `false`.
   - `cache` [LevelDB](https://ghub.io/level) - An optional `level` instance in which
-  to store preprocessed content. See [Usage with Cache](#usage-with-cache).
+    to store preprocessed content. See [Usage with Cache](#usage-with-cache).
+  - `ignoreMissing` - Swallow errors for missing languages (`boolean`, default: `false`). By default, unregistered syntaxes
+    throw an error when they are used. Pass `true` to swallow those errors and thus ignore code with unknown code languages.
 
 Returns a promise. The resolved object looks like this:
 

--- a/test/fixtures/unknown-language.md
+++ b/test/fixtures/unknown-language.md
@@ -1,0 +1,11 @@
+Let's create the own language
+
+```the-unknown-language-whats-actually-graphql
+query {
+  something {
+    another {
+      lets more
+    }
+  }
+}
+```

--- a/test/fixtures/unknown-language.md
+++ b/test/fixtures/unknown-language.md
@@ -1,6 +1,6 @@
 Let's create the own language
 
-```the-unknown-language-whats-actually-graphql
+```some-unknown-language
 query {
   something {
     another {

--- a/test/index.js
+++ b/test/index.js
@@ -68,12 +68,12 @@ describe('hubdown', () => {
     file.content.should.include('<em>Markdown</em>')
   })
 
-  describe('ignoreMissing', () => {
-    it('throw an error when unknown language is present', () => {
+  describe('highlight.ignoreMissing option', () => {
+    it('throws an error when unknown language is present', () => {
       return hubdown(fixtures.unknownLanguage).should.be.rejectedWith(/Unknown language: `some-unknown-language`/)
     })
 
-    it('should work when ignoreMissing on the scene', async () => {
+    it('should work when the highlight.ignoreMissing option is true', async () => {
       const file = await hubdown(fixtures.unknownLanguage, { highlight: { ignoreMissing: true } })
       $ = cheerio.load(file.content)
       fixtures.unknownLanguage.should.include('```some-unknown-language')

--- a/test/index.js
+++ b/test/index.js
@@ -70,14 +70,14 @@ describe('hubdown', () => {
 
   describe('ignoreMissing', () => {
     it('throw an error when unknown language is present', () => {
-      return hubdown(fixtures.unknownLanguage).should.to.be.rejectedWith(/Unknown language: `the-unknown-language-whats-actually-graphql`/)
+      return hubdown(fixtures.unknownLanguage).should.to.be.rejectedWith(/Unknown language: `some-unknown-language`/)
     })
 
     it('should work when ignoreMissing on the scene', async () => {
       const file = await hubdown(fixtures.unknownLanguage, { ignoreMissing: true })
       $ = cheerio.load(file.content)
-      fixtures.unknownLanguage.should.include('```the-unknown-language-whats-actually-graphql')
-      $('pre > code.hljs.language-the-unknown-language-whats-actually-graphql').length.should.equal(1)
+      fixtures.unknownLanguage.should.include('```some-unknown-language')
+      $('pre > code.hljs.language-some-unknown-language').length.should.equal(1)
     })
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -70,7 +70,7 @@ describe('hubdown', () => {
 
   describe('ignoreMissing', () => {
     it('throw an error when unknown language is present', () => {
-      return hubdown(fixtures.unknownLanguage).should.to.be.rejectedWith(/Unknown language: `some-unknown-language`/)
+      return hubdown(fixtures.unknownLanguage).should.be.rejectedWith(/Unknown language: `some-unknown-language`/)
     })
 
     it('should work when ignoreMissing on the scene', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -74,7 +74,7 @@ describe('hubdown', () => {
     })
 
     it('should work when ignoreMissing on the scene', async () => {
-      const file = await hubdown(fixtures.unknownLanguage, { ignoreMissing: true })
+      const file = await hubdown(fixtures.unknownLanguage, { highlight: { ignoreMissing: true } })
       $ = cheerio.load(file.content)
       fixtures.unknownLanguage.should.include('```some-unknown-language')
       $('pre > code.hljs.language-some-unknown-language').length.should.equal(1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,6 +675,13 @@ ccount@^1.0.0, ccount@^1.0.3:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.5.tgz#ac82a944905a65ce204eb03023157edf29425c17"
   integrity sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==
 
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
+
 chai@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"


### PR DESCRIPTION
This PR adds `ignoreMissing` option what allows skipping checking for valid language names.

/cc @zeke @sarahs for GH docs review side